### PR TITLE
Fix undefined prop name in must-colocate-fragment-spreads

### DIFF
--- a/src/rule-must-colocate-fragment-spreads.js
+++ b/src/rule-must-colocate-fragment-spreads.js
@@ -170,6 +170,7 @@ function checkColocation(context) {
         node.specifiers.forEach(specifier => {
           if (
             allowNamedImports &&
+            specifier.imported &&
             isFirstLetterUppercase(specifier.imported.name)
           ) {
             foundImportedModules.push({


### PR DESCRIPTION
it would fail for default import, e.g. `import React from 'react';`