### PR TITLE
Update error message for must-colocate-fragment-spreads

### DIFF
--- a/src/rule-must-colocate-fragment-spreads.js
+++ b/src/rule-must-colocate-fragment-spreads.js
@@ -155,10 +155,12 @@ function checkColocation(context) {
               loc: utils.getLoc(context, node, queriedFragments[fragment]),
               message:
                 `This spreads the fragment \`${fragment}\` but ` +
-                'this module does not use it directly. If a different module ' +
-                'needs this information, that module should directly define a ' +
-                'fragment querying for that data, colocated next to where the ' +
-                'data is used.\n'
+                `this module does not use it directly or the fragment is named incorrectly. If a different module ` +
+                `needs the data from this fragment, that module should directly define it's own fragment ` +
+                `to query for it's own data, and such fragment should be spread in the parent component.` +
+                `The naming convention is <nameOfComponentCamelCase>_<optionalSuffix>. ` +
+                `The <nameOfComponentCamelCase> must match the import name. The optional suffix should be separated ` +
+                `by underscore (usually when you need to pass multiple fragments to the same component).\n`
             });
           }
         }

--- a/test/must-colocate-fragment-spreads.js
+++ b/test/must-colocate-fragment-spreads.js
@@ -20,10 +20,12 @@ const ruleTester = new RuleTester({
 function unusedFieldsWarning(fragment) {
   return (
     `This spreads the fragment \`${fragment}\` but ` +
-    'this module does not use it directly. If a different module ' +
-    'needs this information, that module should directly define a ' +
-    'fragment querying for that data, colocated next to where the ' +
-    'data is used.\n'
+    `this module does not use it directly or the fragment is named incorrectly. If a different module ` +
+    `needs the data from this fragment, that module should directly define it's own fragment ` +
+    `to query for it's own data, and such fragment should be spread in the parent component.` +
+    `The naming convention is <nameOfComponentCamelCase>_<optionalSuffix>. ` +
+    `The <nameOfComponentCamelCase> must match the import name. The optional suffix should be separated ` +
+    `by underscore (usually when you need to pass multiple fragments to the same component).\n`
   );
 }
 


### PR DESCRIPTION
Update the error message for `must-colocate-fragment-spreads` rule so it includes an explanation of what is wrong.